### PR TITLE
use flattened package_name_array to loop in legacy codepath

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -33,7 +33,7 @@ def do_action(new_resource, action)
       action action
     end
   rescue Chef::Exceptions::ValidationFailed
-    new_resource.package_name.each_with_index do |package_name, i|
+    new_resource.package_name_array.each_with_index do |package_name, i|
       version = version_array[i] if version_array
       package package_name do
         version version if version


### PR DESCRIPTION
We should loop over the flattened array `package_name_array`, instead of looping over `new_resource.package_name` directly, which may be a String or an (nested) Array.

We do this in the [definition codepath](https://github.com/lamont-cookbooks/multipackage/blob/master/definitions/default.rb#L5) and if the Chef12 [LWRP codepath](https://github.com/lamont-cookbooks/multipackage/pull/5/files#diff-a27dfd053e213b0e3bff4c49b8a9894eR29), but not if we call the LWRP directly using a 'legacy' Chef versions. I suspect this fixes #1, fwiw.
