### PR TITLE
Fix timeout; fix multipackage supported check

### DIFF
--- a/definitions/default.rb
+++ b/definitions/default.rb
@@ -28,7 +28,7 @@ module MultipackageDefinitionImpl
     end
     versions = [params[:version]].flatten if params[:version]
     options = params[:options]
-    timeout = params[:timeout]
+    timeout = params[:per_package_timeout]
     action = params[:action] || :install
 
     t = begin
@@ -62,7 +62,7 @@ module MultipackageDefinitionImpl
     end
 
     t.options(options) if options
-    t.timeout(timeout) if timeout
+    t.per_package_timeout(timeout) if timeout
 
     t
   end


### PR DESCRIPTION
* We now support a per-package timeout which is what we want for something
  dynamic like this
* Recent changes meant nothing on redhat every tried to use multipackage
  because `!foo == bar` is not the same as `foo != bar`. Fixed that.