### PR TITLE
remove multipackage and drop chef-12 support

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,9 +5,7 @@ source_url "https://github.com/lamont-cookbooks/multipackage"
 issues_url "https://github.com/lamont-cookbooks/multipackage/issues"
 description "Accumulated installation of multiple packages across multiple cookbooks"
 long_description "Accumulated installation of multiple packages across multiple cookbooks"
-version "4.0.1"
+version "5.0.0"
 name "multipackage"
 
-depends "compat_resource"
-
-chef_version ">= 12.0.0" if respond_to?(:chef_version)
+chef_version ">= 13.0.0"


### PR DESCRIPTION
bump to v5.0.0 as well.

closes #18
